### PR TITLE
feat!: Build proper CLI with Thor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Upgrade Ruby from 2.6.5 (EOL) to 3.4.1; require >= 3.3
 * Fix BibleGateway and NetBible API endpoints (http → https)
 * Add `Votd::OurManna` provider — free, no-auth JSON API from ourmanna.com (NIV)
+* **Breaking:** Replace stub CLI with Thor-based CLI. The `votd` command now
+  requires a subcommand: `votd verse` (with `--provider`, `--translation`,
+  `--format` options), `votd version`, `votd help`.
 * Deprecate `Votd::ESVBible` — the gnpcb.org endpoint has been shut down.
   `ESVBible.new` now raises `Votd::VotdError` with a message directing users
   to `Votd::BibleGateway.new(:esv)` as a replacement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,4 +42,4 @@ This is a Ruby gem (`votd`) that wraps Bible verse-of-the-day web services.
 
 **Testing:** Uses RSpec + WebMock with hand-crafted fixtures (not VCR cassettes) in `spec/fixtures/<provider>/`. HTTP calls are stubbed via `fake_a_uri(uri, fixture_path)` and `fake_a_broken_uri(uri)` helpers in `spec/spec_helper.rb`. To test against live APIs run `bundle exec ruby bin/smoke_test`.
 
-**CLI:** `bin/votd` prints the BibleGateway VotD to stdout using `CommandLine` helpers.
+**CLI:** `Votd::CLI` (`lib/votd/cli.rb`) is a Thor-based CLI invoked by `bin/votd`. Supports `verse` (with `--provider`, `--translation`, `--format`) and `version` subcommands.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,17 @@ This returns the custom formatted text, or you can call the `.to_text` method
 when ready, and your custom text will be output.
 
 ## Command Line
-For command-line usage see [here](https://github.com/Sevenview/votd/wiki/Shell-Tool)
+
+```bash
+votd verse                              # BibleGateway NIV (default)
+votd verse -p netbible                  # NetBible provider
+votd verse -p ourmanna                  # OurManna provider
+votd verse --translation kjv            # BibleGateway with KJV
+votd verse -f html                      # HTML output
+votd verse -f json                      # JSON output
+votd verse --help                       # Show options
+votd version                            # Show gem version
+```
 
 ## Documentation
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 ## Todo
 
-[ ] Update `votd` command-line version. Currently only a bare stub of an app.
+[x] Update `votd` command-line version. Currently only a bare stub of an app.
 [ ] Generate a proper error when web service throws error and allow end-user
     to come up with their own fallback verse/handling.

--- a/bin/votd
+++ b/bin/votd
@@ -1,25 +1,9 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-# allow this to run from development environment
-$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'votd'
-require 'votd/helper/command_line'
+require "votd"
+require "votd/cli"
 
-include Votd::Helper::CommandLine
-
-votd = Votd::BibleGateway.new
-#votd = Votd::NetBible.new
-#votd = Votd::ESVBible.new
-#votd = Votd::Base.new
-
-LINE_WIDTH = 40
-
-banner("VERSE OF THE DAY for #{votd.date.to_s}", LINE_WIDTH) { }
-puts "\n"
-puts word_wrap(votd.to_text, LINE_WIDTH)
-
-if votd.copyright
-  puts "\n"
-  puts banner(word_wrap(votd.copyright, LINE_WIDTH), LINE_WIDTH)
-end
+Votd::CLI.start(ARGV)

--- a/lib/votd/cli.rb
+++ b/lib/votd/cli.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "thor"
+require "votd/helper/command_line"
+
+module Votd
+  class CLI < Thor
+    def self.exit_on_failure?
+      true
+    end
+
+    desc "verse", "Display today's Bible verse of the day"
+    option :provider, type: :string, default: "biblegateway", aliases: "-p",
+      desc: "VotD provider (biblegateway, netbible, ourmanna)"
+    option :translation, type: :string, default: "niv",
+      desc: "Bible translation for BibleGateway (e.g. kjv, esv, nlt)"
+    option :format, type: :string, default: "text", aliases: "-f",
+      desc: "Output format (text, html, json)"
+    option :help, type: :boolean, aliases: "-h", hide: true
+    def verse
+      return invoke(:help, ["verse"]) if options[:help]
+      votd = build_votd(options[:provider], options[:translation])
+      output(votd, options[:format])
+    rescue InvalidBibleVersion
+      warn "Error: Unknown translation '#{options[:translation]}'"
+      warn "Valid translations: #{BibleGateway::BIBLE_VERSIONS.keys.join(", ")}"
+      exit 1
+    end
+
+    desc "version", "Show votd gem version"
+    def version
+      puts "votd #{Votd::VERSION}"
+    end
+
+    private
+
+    def build_votd(provider, translation)
+      case provider
+      when "biblegateway" then BibleGateway.new(translation.to_sym)
+      when "netbible" then NetBible.new
+      when "ourmanna" then OurManna.new
+      else
+        warn "Error: Unknown provider '#{provider}'"
+        warn "Valid providers: biblegateway, netbible, ourmanna"
+        exit 1
+      end
+    end
+
+    def output(votd, format)
+      case format
+      when "text" then output_text(votd)
+      when "html" then puts votd.to_html
+      when "json" then output_json(votd)
+      else
+        warn "Error: Unknown format '#{format}'"
+        warn "Valid formats: text, html, json"
+        exit 1
+      end
+    end
+
+    def output_text(votd)
+      line_width = 40
+      Helper::CommandLine.banner("VERSE OF THE DAY for #{votd.date}", line_width)
+      puts "\n"
+      puts Helper::CommandLine.word_wrap(votd.to_text, line_width)
+
+      if votd.copyright
+        puts "\n"
+        Helper::CommandLine.banner(Helper::CommandLine.word_wrap(votd.copyright, line_width), line_width)
+      end
+    end
+
+    def output_json(votd)
+      puts JSON.pretty_generate({
+        reference: votd.reference,
+        text: votd.text,
+        version: votd.version,
+        version_name: votd.version_name,
+        date: votd.date.to_s,
+        link: votd.link,
+        copyright: votd.copyright
+      })
+    end
+  end
+end

--- a/votd.gemspec
+++ b/votd.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.3"
 
-  gem.add_dependency "httparty"
   gem.add_dependency "feedjira"
+  gem.add_dependency "httparty"
+  gem.add_dependency "thor"
 end


### PR DESCRIPTION
## Summary

- Replace bare stub `bin/votd` with a Thor-based CLI
- Add `votd verse` command with `--provider`, `--translation`, and `--format` options
- Add `votd version` command
- Add `thor` as a runtime dependency

**Breaking change:** `votd` alone now shows help instead of fetching a verse. Use `votd verse` instead.

## Test plan

- [ ] `votd verse` — default BibleGateway NIV text output
- [ ] `votd verse -p netbible` / `-p ourmanna` — provider selection
- [ ] `votd verse --translation kjv` — BibleGateway translation
- [ ] `votd verse -f html` / `-f json` — output formats
- [ ] `votd verse --help` — shows options
- [ ] `votd help` — shows command list
- [ ] `votd version` — shows gem version
- [ ] Invalid provider/translation/format — friendly error messages

Closes #13