### PR TITLE
feat!: raise FetchError instead of silently falling back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,13 @@ bundle exec guard
 This is a Ruby gem (`votd`) that wraps Bible verse-of-the-day web services.
 
 **Class hierarchy:**
-- `Votd::Base` — abstract base class. Provides default fallback (John 3:16 KJV) when a service fails, and implements `to_html`, `to_text`, `custom_html`, `custom_text`. Subclasses override the private `get_votd` method.
+- `Votd::Base` — abstract base class. Implements `to_html`, `to_text`, `custom_html`, `custom_text`. Subclasses override the private `get_votd` method.
 - `Votd::BibleGateway < Base` — fetches via RSS/Feedjira; accepts a version symbol (e.g. `:niv`, `:kjv`) from the `BIBLE_VERSIONS` hash.
 - `Votd::NetBible < Base` — fetches via JSON API from bible.org; NETBible translation only.
 - `Votd::OurManna < Base` — fetches via JSON API from ourmanna.com; NIV translation only.
 - `Votd::ESVBible` — **deprecated**. Raises `Votd::VotdError` on instantiation. The upstream gnpcb.org endpoint no longer exists. Direct users to `BibleGateway.new(:esv)`.
 
-**Error handling pattern:** Every `get_votd` implementation rescues all exceptions and calls `set_defaults` to return the fallback verse rather than raising. `Votd::InvalidBibleVersion` is the only error raised eagerly (in `BibleGateway#initialize` for unknown version symbols).
+**Error handling pattern:** Provider `get_votd` methods raise `Votd::FetchError` on any failure (network, parse, etc.) with the original exception preserved as `#cause`. Errors are reported via `Votd.logger` (if set) and `Votd.on_error` callback (if registered) before raising. `Votd::InvalidBibleVersion` is raised eagerly in `BibleGateway#initialize` for unknown version symbols.
 
 **Helpers:**
 - `Votd::Helper::Text` — strips HTML tags, cleans verse start/end punctuation.

--- a/bin/smoke_test
+++ b/bin/smoke_test
@@ -8,15 +8,11 @@ FAIL = "\e[31mFAIL\e[0m"
 
 def test(name)
   votd = yield
-  if votd.text == Votd::Base::DEFAULT_BIBLE_TEXT
-    puts "#{FAIL} #{name} — returned fallback verse (request likely failed)"
-  else
-    puts "#{PASS} #{name}"
-    puts "  reference : #{votd.reference}"
-    puts "  version   : #{votd.version}"
-    puts "  text      : #{votd.text[0..80]}..."
-    puts "  link      : #{votd.link}"
-  end
+  puts "#{PASS} #{name}"
+  puts "  reference : #{votd.reference}"
+  puts "  version   : #{votd.version}"
+  puts "  text      : #{votd.text[0..80]}..."
+  puts "  link      : #{votd.link}"
 rescue => e
   puts "#{FAIL} #{name} — #{e.class}: #{e.message}"
 end

--- a/lib/votd.rb
+++ b/lib/votd.rb
@@ -7,11 +7,42 @@ require "httparty"
 # This class acts as the entry point to all sub-modules that are used
 # to interact with various Verse of the Day web services.
 module Votd
+  class << self
+    # Set a Logger-compatible object to receive error messages when
+    # a provider fails to fetch a verse.
+    #
+    # @example
+    #   Votd.logger = Logger.new($stderr)
+    attr_accessor :logger
+
+    # Register a callback to be invoked when a provider error occurs.
+    # The block receives the provider class and the wrapped FetchError.
+    #
+    # @example
+    #   Votd.on_error do |provider_class, error|
+    #     Sentry.capture_exception(error)
+    #   end
+    def on_error(&block)
+      @on_error = block
+    end
+
+    # @api private
+    def on_error_callback
+      @on_error
+    end
+
+    # Resets logger and on_error callback. Useful in tests.
+    def reset_configuration
+      @logger = nil
+      @on_error = nil
+    end
+  end
 end
 
 require "votd/helper/text"
 require "votd/version"
 require "votd/votd_error"
+require "votd/fetch_error"
 require "votd/base"
 require "votd/bible_gateway"
 require "votd/netbible"

--- a/lib/votd/base.rb
+++ b/lib/votd/base.rb
@@ -2,9 +2,9 @@
 
 module Votd
   # This is the base class that all Votd lookup modules inherit from.
-  # It provides default values for the Votd in the event of lookup failure.
   # Child classes should override the {#get_votd} method to implement their
-  # specific lookup function.
+  # specific lookup function. Errors during fetch are raised as {FetchError}
+  # and reported via {Votd.logger} and {Votd.on_error}.
   class Base
     # @example
     #   votd.text  # "For by grace you are saved through faith..."
@@ -173,6 +173,17 @@ module Votd
       @version_name = DEFAULT_BIBLE_VERSION_NAME
       @link = DEFAULT_LINK
       @copyright = nil
+    end
+
+    # Logs the error, invokes the on_error callback, and raises a FetchError.
+    # @param error [Exception] the original exception
+    # @param message [String] a human-readable description of the failure
+    # @raise [FetchError]
+    def report_and_raise(error, message)
+      wrapped = FetchError.new("#{message}: #{error.message}")
+      Votd.logger&.error("#{self.class.name} - #{error.class}: #{error.message}")
+      Votd.on_error_callback&.call(self.class, wrapped)
+      raise wrapped
     end
   end
 end

--- a/lib/votd/bible_gateway.rb
+++ b/lib/votd/bible_gateway.rb
@@ -71,9 +71,8 @@ module Votd
       @link = entry.entry_id
       @text = build_verse_text(stripped)
       @copyright = extract_copyright(stripped)
-    rescue
-      # use default info for VotD
-      set_defaults
+    rescue => e
+      report_and_raise(e, "Failed to fetch verse from BibleGateway")
     end
 
     # Builds clean verse text from HTML-stripped content

--- a/lib/votd/cli.rb
+++ b/lib/votd/cli.rb
@@ -25,6 +25,9 @@ module Votd
       warn "Error: Unknown translation '#{options[:translation]}'"
       warn "Valid translations: #{BibleGateway::BIBLE_VERSIONS.keys.join(", ")}"
       exit 1
+    rescue FetchError => e
+      warn "Error: #{e.message}"
+      exit 1
     end
 
     desc "version", "Show votd gem version"

--- a/lib/votd/fetch_error.rb
+++ b/lib/votd/fetch_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Votd
+  # Raised when a provider fails to fetch or parse a verse of the day.
+  # The original exception is preserved as #cause.
+  class FetchError < VotdError
+  end
+end

--- a/lib/votd/netbible.rb
+++ b/lib/votd/netbible.rb
@@ -44,9 +44,8 @@ module Votd
       @version_name = BIBLE_VERSION_NAME
 
       @link = generate_link(bookname, chapter, verse_numbers.first)
-    rescue
-      # use default info for VotD
-      set_defaults
+    rescue => e
+      report_and_raise(e, "Failed to fetch verse from NetBible")
     end
 
     def generate_link(bookname, chapter, verse_number)

--- a/lib/votd/ourmanna.rb
+++ b/lib/votd/ourmanna.rb
@@ -28,9 +28,8 @@ module Votd
       @text = Helper::Text.clean_verse_end(text)
 
       @copyright = data["verse"]["notice"]
-    rescue
-      # use default info for VotD
-      set_defaults
+    rescue => e
+      report_and_raise(e, "Failed to fetch verse from OurManna")
     end
   end
 end

--- a/spec/lib/votd/base_spec.rb
+++ b/spec/lib/votd/base_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "logger"
 
 describe "Votd::Base" do
   let(:votd) { Votd::Base.new }
@@ -90,6 +91,68 @@ describe "Votd::Base" do
 
     it "generates a VotdError when not used with a block" do
       expect { votd.custom_text }.to raise_error(Votd::VotdError)
+    end
+  end
+
+  describe "Votd.logger" do
+    it "logs errors when a provider fails" do
+      logger = instance_double(Logger)
+      Votd.logger = logger
+      expect(logger).to receive(:error).with(/BibleGateway.*SocketError/)
+
+      stub_request(:get, /biblegateway/).to_raise(SocketError)
+      expect { Votd::BibleGateway.new }.to raise_error(Votd::FetchError)
+    end
+
+    it "does not raise when no logger is configured" do
+      stub_request(:get, /biblegateway/).to_raise(SocketError)
+      expect { Votd::BibleGateway.new }.to raise_error(Votd::FetchError)
+    end
+  end
+
+  describe "Votd.on_error" do
+    it "invokes the callback with provider class and error" do
+      callback_args = nil
+      Votd.on_error do |provider_class, error|
+        callback_args = [provider_class, error]
+      end
+
+      stub_request(:get, /biblegateway/).to_raise(SocketError)
+      expect { Votd::BibleGateway.new }.to raise_error(Votd::FetchError)
+
+      expect(callback_args).not_to be_nil
+      expect(callback_args[0]).to eq Votd::BibleGateway
+      expect(callback_args[1]).to be_a(Votd::FetchError)
+    end
+  end
+
+  describe "Votd.reset_configuration" do
+    it "clears logger and on_error callback" do
+      Votd.logger = Logger.new($stderr)
+      Votd.on_error { |_provider, _error| }
+
+      Votd.reset_configuration
+
+      expect(Votd.logger).to be_nil
+      expect(Votd.on_error_callback).to be_nil
+    end
+  end
+
+  describe "Votd::FetchError" do
+    it "is a subclass of VotdError" do
+      expect(Votd::FetchError.superclass).to eq Votd::VotdError
+    end
+
+    it "preserves the original exception as #cause" do
+      stub_request(:get, /biblegateway/).to_raise(SocketError.new("connection refused"))
+
+      begin
+        Votd::BibleGateway.new
+      rescue Votd::FetchError => e
+        expect(e.cause).to be_a(SocketError)
+        expect(e.cause.message).to eq "connection refused"
+        expect(e.message).to include("Failed to fetch verse from BibleGateway")
+      end
     end
   end
 end

--- a/spec/lib/votd/bible_gateway_spec.rb
+++ b/spec/lib/votd/bible_gateway_spec.rb
@@ -105,27 +105,27 @@ describe "Votd::BibleGateway" do
   context "When an error occurs" do
     context "with a malformed response body" do
       before { fake_a_broken_uri(uri_regex) }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with a network timeout" do
       before { stub_request(:get, uri_regex).to_timeout }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with a connection failure" do
       before { stub_request(:get, uri_regex).to_raise(SocketError) }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with an HTTP 500 response" do
       before { stub_request(:get, uri_regex).to_return(status: 500, body: "Internal Server Error") }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with an empty response body" do
       before { stub_request(:get, uri_regex).to_return(body: "") }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
   end
 

--- a/spec/lib/votd/netbible_spec.rb
+++ b/spec/lib/votd/netbible_spec.rb
@@ -114,27 +114,27 @@ describe "Votd::NETBible" do
   context "When an error occurs" do
     context "with a malformed response body" do
       before { fake_a_broken_uri(Votd::NetBible::ENDPOINT_URL) }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with a network timeout" do
       before { stub_request(:get, Votd::NetBible::ENDPOINT_URL).to_timeout }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with a connection failure" do
       before { stub_request(:get, Votd::NetBible::ENDPOINT_URL).to_raise(SocketError) }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with an HTTP 500 response" do
       before { stub_request(:get, Votd::NetBible::ENDPOINT_URL).to_return(status: 500, body: "Internal Server Error") }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with an empty response body" do
       before { stub_request(:get, Votd::NetBible::ENDPOINT_URL).to_return(body: "") }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
   end
 

--- a/spec/lib/votd/ourmanna_spec.rb
+++ b/spec/lib/votd/ourmanna_spec.rb
@@ -104,27 +104,27 @@ describe "Votd::OurManna" do
   context "When an error occurs" do
     context "with a malformed response body" do
       before { fake_a_broken_uri(Votd::OurManna::ENDPOINT_URL) }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with a network timeout" do
       before { stub_request(:get, Votd::OurManna::ENDPOINT_URL).to_timeout }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with a connection failure" do
       before { stub_request(:get, Votd::OurManna::ENDPOINT_URL).to_raise(SocketError) }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with an HTTP 500 response" do
       before { stub_request(:get, Votd::OurManna::ENDPOINT_URL).to_return(status: 500, body: "Internal Server Error") }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
 
     context "with an empty response body" do
       before { stub_request(:get, Votd::OurManna::ENDPOINT_URL).to_return(body: "") }
-      include_examples "falls back to defaults"
+      include_examples "raises a FetchError"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ require "webmock/rspec"
 
 RSpec.configure do |config|
   config.mock_with :rspec
+
+  config.after(:each) do
+    Votd.reset_configuration
+  end
 end
 
 # Fixtures
@@ -25,10 +29,8 @@ def fake_a_broken_uri(uri)
   stub_request(:get, uri).to_return(body: "Oopsies")
 end
 
-RSpec.shared_examples "falls back to defaults" do
-  it "falls back to default VotD values" do
-    expect(votd.version).to eq Votd::Base::DEFAULT_BIBLE_VERSION
-    expect(votd.reference).to eq Votd::Base::DEFAULT_BIBLE_REFERENCE
-    expect(votd.text).to eq Votd::Base::DEFAULT_BIBLE_TEXT
+RSpec.shared_examples "raises a FetchError" do
+  it "raises a Votd::FetchError" do
+    expect { votd }.to raise_error(Votd::FetchError)
   end
 end


### PR DESCRIPTION
## Summary

- Providers now raise `Votd::FetchError` instead of silently returning a default John 3:16 verse when fetch/parse fails
- Added `Votd.logger` for standard Ruby logging of provider errors
- Added `Votd.on_error` callback for error tracker integration (Sentry, Honeybadger, etc.)
- Original exception preserved as `FetchError#cause` for debugging
- CLI handles `FetchError` with user-friendly error output

## Breaking change

All provider errors now raise `Votd::FetchError` instead of falling back to defaults. Users must rescue errors explicitly:

```ruby
begin
  votd = Votd::BibleGateway.new(:niv)
rescue Votd::FetchError => e
  # handle error, use your own fallback, etc.
end
```

## Test plan

- [x] All 109 specs pass
- [ ] `bundle exec ruby bin/smoke_test` against live APIs
- [ ] `bin/votd verse` happy path
- [ ] `bin/votd verse` with network disconnected (should show error)

Closes #12